### PR TITLE
:books: change hankey to poop

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ emoji                                   | emoji                      | commit
 📝                                      | `:pencil:`                 | Changes/Fixing the code or language
 🔥                                      | `:fire:`                   | Removing code or files
 ♻️                                      | `:recycle:`                | Recycle code or files
-💩                                      | `:hankey:`                | Writing bad code that needs to be improved.
+💩                                      | `:poop:`                | Writing bad code that needs to be improved.
 
 ##### general
 emoji                                   | emoji                      | commit


### PR DESCRIPTION
'Hankey' can be worked only Github. Meanwhile, 'Poop' are able to use Bitbucket also. So, I change to 'Poop', or you have other emoji instead of it.